### PR TITLE
Add Vim keybindings mode for SQL editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A beautiful, fast TUI SQL editor for PostgreSQL written in Rust.
 - **Query Results Table**: Scrollable, navigable results with cell selection
 - **Query History**: Persistent history with search capability
 - **Connection Management**: Save and manage multiple PostgreSQL connections
+- **Vim Keybindings**: Optional vim mode with Normal, Insert, Visual, and Visual Line modes
 - **Keyboard-First Design**: Efficient navigation without leaving the keyboard
 - **Dark Theme**: Easy on the eyes for long coding sessions
 
@@ -128,6 +129,41 @@ cargo install pgrsql
 | `Ctrl+Left/Right` | Move by word |
 | `Home/End` | Move to line start/end |
 | `Ctrl+Home/End` | Move to document start/end |
+| `F2` or `Alt+V` | Toggle Vim mode |
+
+### Vim Mode
+
+Press `F2` or `Alt+V` in the editor to toggle Vim keybindings. Your preference is saved across sessions.
+
+The status bar shows the current mode: `-- NORMAL --`, `-- INSERT --`, `-- VISUAL --`, or `-- V-LINE --`.
+
+#### Vim Normal Mode
+| Key | Action |
+|-----|--------|
+| `i` / `a` | Insert before/after cursor |
+| `I` / `A` | Insert at line start/end |
+| `o` / `O` | Open line below/above |
+| `h` `j` `k` `l` | Move left/down/up/right |
+| `w` / `b` / `e` | Word forward/back/end |
+| `0` / `$` / `^` | Line start/end/first non-blank |
+| `gg` / `G` | Go to top/bottom |
+| `{` / `}` | Paragraph up/down |
+| `x` / `X` | Delete char forward/backward |
+| `dd` | Delete line |
+| `yy` | Yank (copy) line |
+| `d`+motion | Delete with motion |
+| `c`+motion | Change with motion |
+| `p` / `P` | Paste after/before |
+| `v` / `V` | Enter Visual / Visual Line mode |
+
+#### Vim Visual Mode
+| Key | Action |
+|-----|--------|
+| Motion keys | Extend selection |
+| `d` / `x` | Delete selection |
+| `y` | Yank selection |
+| `c` | Change selection |
+| `Esc` | Back to Normal mode |
 
 #### Sidebar
 | Key | Action |

--- a/src/ui/components.rs
+++ b/src/ui/components.rs
@@ -986,7 +986,7 @@ fn draw_help_overlay(frame: &mut Frame, app: &App) {
         "   Ctrl+↑/↓       Navigate history",
         "   Ctrl+C/X/V     Copy/Cut/Paste",
         "   Ctrl+A         Select all",
-        "   Ctrl+Shift+V   Toggle Vim mode",
+        "   F2/Alt+V       Toggle Vim mode",
         "   Tab            Insert spaces",
         "",
         " SIDEBAR",


### PR DESCRIPTION
## Summary

Implements **Issue #17** — an optional Vim-style editing mode for the SQL editor.

- **Ctrl+Shift+V** toggles between Vim and standard editing mode
- Preference persisted to `~/.config/pgrsql/vim_mode`
- Mode indicator shown in status bar (NORMAL/INSERT/VISUAL/V-LINE)

### Normal Mode
| Key | Action |
|-----|--------|
| `h/j/k/l` | Move left/down/up/right |
| `w/b/e` | Word forward/backward/end |
| `0/$/^` | Line start/end/first non-whitespace |
| `gg/G` | Go to first/last line |
| `i/a/I/A` | Enter Insert mode (at cursor/after/line start/line end) |
| `o/O` | New line below/above, enter Insert |
| `v/V` | Enter Visual/Visual-Line mode |
| `x` | Delete character |
| `dd/dw/d$/d0` | Delete line/word/to-end/to-start |
| `yy/yw/y$` | Yank line/word/to-end |
| `cc/cw/c$` | Change line/word/to-end |
| `p/P` | Paste after/before cursor |
| Count prefix (e.g., `3j`) | Repeat motion N times |

### Insert Mode
- Standard editing keybindings
- `Esc` returns to Normal mode

### Visual/V-Line Mode
- Motions extend selection
- `d/y/c` operate on selection

## Changes

| File | Changes |
|------|---------|
| `src/ui/app.rs` | Added `VimMode` enum, vim state fields, `handle_vim_normal_input()`, `handle_vim_insert_input()`, `handle_vim_visual_input()`, vim helpers, toggle keybinding, preference persistence |
| `src/ui/components.rs` | Added vim mode indicator in status bar, updated help overlay |

## Test plan

- [ ] All 124 existing tests pass
- [ ] `cargo clippy` clean
- [ ] `cargo fmt` clean
- [ ] Manual test: Ctrl+Shift+V enables vim mode, status bar shows "NORMAL"
- [ ] Manual test: `i` enters insert mode, `Esc` returns to normal
- [ ] Manual test: `h/j/k/l` navigate, `w/b` word motions work
- [ ] Manual test: `dd` deletes line, `yy` yanks, `p` pastes
- [ ] Manual test: `v` enters visual mode, `d` deletes selection
- [ ] Manual test: Ctrl+Enter/F5 executes query in all modes
- [ ] Manual test: Ctrl+Shift+V disables vim mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)