### PR TITLE
Add query execution statistics dashboard

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -293,15 +293,27 @@ pub struct QueryStats {
 
 impl QueryStats {
     pub fn avg_time_ms(&self) -> f64 {
-        if self.total_queries == 0 { 0.0 } else { self.total_time_ms / self.total_queries as f64 }
+        if self.total_queries == 0 {
+            0.0
+        } else {
+            self.total_time_ms / self.total_queries as f64
+        }
     }
 
     pub fn success_rate(&self) -> f64 {
-        if self.total_queries == 0 { 0.0 } else { (self.successful_queries as f64 / self.total_queries as f64) * 100.0 }
+        if self.total_queries == 0 {
+            0.0
+        } else {
+            (self.successful_queries as f64 / self.total_queries as f64) * 100.0
+        }
     }
 
     pub fn session_avg_time_ms(&self) -> f64 {
-        if self.session_queries == 0 { 0.0 } else { self.session_total_time_ms / self.session_queries as f64 }
+        if self.session_queries == 0 {
+            0.0
+        } else {
+            self.session_total_time_ms / self.session_queries as f64
+        }
     }
 
     pub fn record_query(&mut self, time_ms: f64, success: bool) {
@@ -309,13 +321,21 @@ impl QueryStats {
         self.session_queries += 1;
         self.total_time_ms += time_ms;
         self.session_total_time_ms += time_ms;
-        if success { self.successful_queries += 1; } else { self.failed_queries += 1; }
+        if success {
+            self.successful_queries += 1;
+        } else {
+            self.failed_queries += 1;
+        }
         if self.total_queries == 1 {
             self.min_time_ms = time_ms;
             self.max_time_ms = time_ms;
         } else {
-            if time_ms < self.min_time_ms { self.min_time_ms = time_ms; }
-            if time_ms > self.max_time_ms { self.max_time_ms = time_ms; }
+            if time_ms < self.min_time_ms {
+                self.min_time_ms = time_ms;
+            }
+            if time_ms > self.max_time_ms {
+                self.max_time_ms = time_ms;
+            }
         }
     }
 }
@@ -1720,7 +1740,8 @@ impl App {
 
             // Record query statistics
             let time_ms = result.execution_time.as_secs_f64() * 1000.0;
-            self.query_stats.record_query(time_ms, result.error.is_none());
+            self.query_stats
+                .record_query(time_ms, result.error.is_none());
 
             // Update status
             if let Some(err) = &result.error {

--- a/src/ui/components.rs
+++ b/src/ui/components.rs
@@ -1518,7 +1518,10 @@ fn draw_stats_panel(frame: &mut Frame, app: &App) {
         Style::default().fg(theme.text_primary),
     )));
     lines.push(Line::from(Span::styled(
-        format!("   Avg time:          {:.2} ms", stats.session_avg_time_ms()),
+        format!(
+            "   Avg time:          {:.2} ms",
+            stats.session_avg_time_ms()
+        ),
         Style::default().fg(theme.text_primary),
     )));
     lines.push(Line::from(""));
@@ -1560,10 +1563,7 @@ fn draw_stats_panel(frame: &mut Frame, app: &App) {
     )));
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(
-        format!(
-            "   Total time:        {:.2} ms",
-            stats.total_time_ms
-        ),
+        format!("   Total time:        {:.2} ms", stats.total_time_ms),
         Style::default().fg(theme.text_primary),
     )));
     lines.push(Line::from(""));


### PR DESCRIPTION
## Summary

- Adds a **Query Statistics** panel accessible via `Ctrl+Shift+S` showing session and all-time query execution metrics
- Tracks total queries, successful/failed counts, success rate, min/max/avg execution times
- Status bar shows live session query count and average execution time after the first query
- Panel supports scrolling with Up/Down arrows and closes with Esc/q

## Implementation Details

### `src/ui/app.rs`
- Added `StatsPanel` variant to the `Focus` enum
- Added `QueryStats` struct with `record_query()`, `avg_time_ms()`, `success_rate()`, and `session_avg_time_ms()` methods
- Added `query_stats` and `stats_scroll` fields to `App`
- Added `handle_stats_input()` for panel navigation
- Integrated stats recording into `execute_query()` flow
- Added `Ctrl+Shift+S` keyboard shortcut to open stats panel
- 3 unit tests for QueryStats struct

### `src/ui/components.rs`
- Added `draw_stats_panel()` function rendering a centered overlay with session and all-time statistics
- Updated `draw()` to render stats panel when focused
- Updated `draw_status_bar()` to show session query count and average time
- Added `Ctrl+Shift+S` to help overlay

## Test plan

- [x] `cargo build` compiles without errors
- [x] `cargo test` - all 228 tests pass
- [ ] Manual: Execute queries and verify stats update in status bar
- [ ] Manual: Press Ctrl+Shift+S to open stats panel and verify metrics
- [ ] Manual: Verify Up/Down scrolling and Esc/q close behavior

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)