### PR TITLE
Fix UI layout: dynamic editor/results split and scrollable help

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -139,6 +139,7 @@ pub struct App {
 
     // Help
     pub show_help: bool,
+    pub help_scroll: usize,
 
     // Autocomplete
     pub autocomplete: AutocompleteState,
@@ -410,6 +411,7 @@ impl App {
             loading_message: String::new(),
             spinner_frame: 0,
             show_help: false,
+            help_scroll: 0,
             autocomplete: AutocompleteState::default(),
 
             explain_plans: Vec::new(),
@@ -1130,7 +1132,20 @@ impl App {
         match key.code {
             KeyCode::Esc | KeyCode::Char('?') | KeyCode::Char('q') => {
                 self.show_help = false;
+                self.help_scroll = 0;
                 self.focus = Focus::Editor;
+            }
+            KeyCode::Up => {
+                self.help_scroll = self.help_scroll.saturating_sub(1);
+            }
+            KeyCode::Down => {
+                self.help_scroll += 1;
+            }
+            KeyCode::PageUp => {
+                self.help_scroll = self.help_scroll.saturating_sub(10);
+            }
+            KeyCode::PageDown => {
+                self.help_scroll += 10;
             }
             _ => {}
         }


### PR DESCRIPTION
## Summary

- Fixed autocomplete popup positioning to use the dynamic `editor_height_percent` instead of a hardcoded `Percentage(40)`, so the popup correctly tracks the editor pane when resized with Ctrl+Shift+Up/Down
- Made the help overlay scrollable (Up/Down/PageUp/PageDown) and adaptive to small terminal sizes, so all keyboard shortcuts are accessible regardless of terminal dimensions
- Added scroll hint to the help overlay footer

## What Changed

- `src/ui/app.rs`: Added `help_scroll` field to `App` struct; added scroll handling (Up/Down/PageUp/PageDown) to `handle_help_input()`
- `src/ui/components.rs`: Fixed `Constraint::Percentage(40)` → `Constraint::Percentage(app.editor_height_percent)` for autocomplete positioning; rewrote `draw_help_overlay()` to support scrolling and dynamic height

## Test Plan

- [ ] Resize the editor/results split with Ctrl+Shift+Up/Down, then trigger autocomplete (type 2+ chars or Ctrl+Space) — the popup should appear correctly positioned relative to the editor cursor
- [ ] Open the help overlay (`?`) in a small terminal (e.g., 40 rows) — should show as much content as fits, with scroll hint at bottom
- [ ] Scroll the help overlay with Up/Down/PageUp/PageDown — all shortcuts should be reachable
- [ ] Press Esc or `?` to close help — scroll position resets
- [ ] Run `cargo test` — all 230 tests pass

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)